### PR TITLE
chore/typos

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1950,7 +1950,7 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
                 switched If a window inside the current tabpage (including a
                 float) already shows the buffer One of these windows will be
                 set as current window temporarily. Otherwise a temporary
-                scratch window (calleed the "autocmd window" for historical
+                scratch window (called the "autocmd window" for historical
                 reasons) will be used.
 
                 This is useful e.g. to call vimL functions that only work with

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8970,7 +8970,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		Otherwise encloses {string} in single-quotes and replaces all
 		"'" with "'\''".
 
-		If {special} is a ||non-zero-arg|:
+		If {special} is a |non-zero-arg|:
 		- Special items such as "!", "%", "#" and "<cword>" will be
 		  preceded by a backslash. The backslash will be removed again
 		  by the |:!| command.
@@ -8980,7 +8980,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		- The "!" character will be escaped. This is because csh and
 		  tcsh use "!" for history replacement even in single-quotes.
 		- The <NL> character is escaped (twice if {special} is
-		  a ||non-zero-arg|).
+		  a |non-zero-arg|).
 
 		If 'shell' contains "fish" in the tail, the "\" character will
 		be escaped because in fish it is used as an escape character

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1246,7 +1246,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
 /// If the current window already shows "buffer", the window is not switched
 /// If a window inside the current tabpage (including a float) already shows the
 /// buffer One of these windows will be set as current window temporarily.
-/// Otherwise a temporary scratch window (calleed the "autocmd window" for
+/// Otherwise a temporary scratch window (called the "autocmd window" for
 /// historical reasons) will be used.
 ///
 /// This is useful e.g. to call vimL functions that only work with the current


### PR DESCRIPTION
- Fixed typo in api.txt
- Fixed type in buffer.c that generates comments in api.txt
- docs: fix two typos in eval.txt
