### PR TITLE
chore/typos

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1950,7 +1950,7 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
                 switched If a window inside the current tabpage (including a
                 float) already shows the buffer One of these windows will be
                 set as current window temporarily. Otherwise a temporary
-                scratch window (calleed the "autocmd window" for historical
+                scratch window (called the "autocmd window" for historical
                 reasons) will be used.
 
                 This is useful e.g. to call vimL functions that only work with

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -468,7 +468,7 @@ extmark position and enter some text, the extmark migrates forward. >
      f o o z|b a r    line (| = cursor)
             4         extmark (after typing "z")
 
-If an extmark is on the last index of a line and you inputsa newline at that
+If an extmark is on the last index of a line and you input a newline at that
 point, the extmark will accordingly migrate to the next line: >
 
      f o o z b a r|   line (| = cursor)

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2481,7 +2481,7 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
                 Parameters: ~
                     {buffer}        Buffer handle, or 0 for current buffer
                     {start_row}     First line index
-                    {start_column}  Last column
+                    {start_column}  First column
                     {end_row}       Last line index
                     {end_column}    Last column
                     {replacement}   Array of lines to use as replacement

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -793,7 +793,7 @@ QuitPre				When using `:quit`, `:wq` or `:qall`, before
 				before QuitPre is triggered.  Can be used to
 				close any non-essential window if the current
 				window is the last ordinary window.
-				See also |ExitPre|, ||WinClosed|.
+				See also |ExitPre|, |WinClosed|.
 							*RemoteReply*
 RemoteReply			When a reply from a Vim that functions as
 				server was received |server2client()|.  The

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -373,39 +373,8 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      Otherwise, all signs use the same
                                      priority.
 
-                                 • float: Options for floating windows:
-                                   • severity: See |diagnostic-severity|.
-                                   • header: (string or table) String to use
-                                     as the header for the floating window. If
-                                     a table, it is interpreted as a [text,
-                                     hl_group] tuple. Defaults to
-                                     "Diagnostics:".
-                                   • source: (string) Include the diagnostic
-                                     source in the message. One of "always" or
-                                     "if_many".
-                                   • format: (function) A function that takes
-                                     a diagnostic as input and returns a
-                                     string. The return value is the text used
-                                     to display the diagnostic.
-                                   • prefix: (function, string, or table)
-                                     Prefix each diagnostic in the floating
-                                     window. If a function, it must have the
-                                     signature (diagnostic, i, total) ->
-                                     (string, string), where {i} is the index
-                                     of the diagnostic being evaluated and
-                                     {total} is the total number of
-                                     diagnostics displayed in the window. The
-                                     function should return a string which is
-                                     prepended to each diagnostic in the
-                                     window as well as an (optional) highlight
-                                     group which will be used to highlight the
-                                     prefix. If {prefix} is a table, it is
-                                     interpreted as a [text, hl_group] tuple
-                                     as in |nvim_echo()|; otherwise, if
-                                     {prefix} is a string, it is prepended to
-                                     each diagnostic in the window with no
-                                     highlight.
-
+                                 • float: Options for floating windows. See
+                                   |vim.diagnostic.open_float()|.
                                  • update_in_insert: (default false) Update
                                    diagnostics in Insert mode (if false,
                                    diagnostics are updated on InsertLeave)
@@ -641,8 +610,21 @@ open_float({bufnr}, {opts})                      *vim.diagnostic.open_float()*
                                diagnostic. Overrides the setting from
                                |vim.diagnostic.config()|.
                              • prefix: (function, string, or table) Prefix
-                               each diagnostic in the floating window.
-                               Overrides the setting from
+                               each diagnostic in the floating window. If a
+                               function, it must have the signature
+                               (diagnostic, i, total) -> (string, string),
+                               where {i} is the index of the diagnostic being
+                               evaluated and {total} is the total number of
+                               diagnostics displayed in the window. The
+                               function should return a string which is
+                               prepended to each diagnostic in the window as
+                               well as an (optional) highlight group which
+                               will be used to highlight the prefix. If
+                               {prefix} is a table, it is interpreted as a
+                               [text, hl_group] tuple as in |nvim_echo()|;
+                               otherwise, if {prefix} is a string, it is
+                               prepended to each diagnostic in the window with
+                               no highlight. Overrides the setting from
                                |vim.diagnostic.config()|.
 
                 Return: ~

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3081,7 +3081,7 @@ bufname([{buf}])						*bufname()*
 	bufname(3)		name of buffer 3
 	bufname("%")		name of current buffer
 	bufname("file2")	name of buffer where "file2" matches.
-
+<
 							*bufnr()*
 bufnr([{buf} [, {create}]])
 		The result is the number of a buffer, as it is displayed by

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8970,7 +8970,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		Otherwise encloses {string} in single-quotes and replaces all
 		"'" with "'\''".
 
-		If {special} is a ||non-zero-arg|:
+		If {special} is a |non-zero-arg|:
 		- Special items such as "!", "%", "#" and "<cword>" will be
 		  preceded by a backslash. The backslash will be removed again
 		  by the |:!| command.
@@ -8980,7 +8980,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		- The "!" character will be escaped. This is because csh and
 		  tcsh use "!" for history replacement even in single-quotes.
 		- The <NL> character is escaped (twice if {special} is
-		  a ||non-zero-arg|).
+		  a |non-zero-arg|).
 
 		If 'shell' contains "fish" in the tail, the "\" character will
 		be escaped because in fish it is used as an escape character

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1593,24 +1593,27 @@ open_floating_preview({contents}, {syntax}, {opts})
                 Parameters: ~
                     {contents}  table of lines to show in window
                     {syntax}    string of syntax to set for opened buffer
-                    {opts}      dictionary with optional fields
-                                • height of floating window
-                                • width of floating window
-                                • wrap boolean enable wrapping of long lines
-                                  (defaults to true)
-                                • wrap_at character to wrap at for computing
-                                  height when wrap is enabled
-                                • max_width maximal width of floating window
-                                • max_height maximal height of floating window
-                                • pad_top number of lines to pad contents at
-                                  top
-                                • pad_bottom number of lines to pad contents
-                                  at bottom
-                                • focus_id if a popup with this id is opened,
-                                  then focus it
-                                • close_events list of events that closes the
+                    {opts}      table with optional fields (additional keys
+                                are passed on to |vim.api.nvim_open_win()|)
+                                • height: (number) height of floating window
+                                • width: (number) width of floating window
+                                • wrap: (boolean, default true) wrap long
+                                  lines
+                                • wrap_at: (string) character to wrap at for
+                                  computing height when wrap is enabled
+                                • max_width: (number) maximal width of
                                   floating window
-                                • focusable (boolean, default true): Make
+                                • max_height: (number) maximal height of
+                                  floating window
+                                • pad_top: (number) number of lines to pad
+                                  contents at top
+                                • pad_bottom: (number) number of lines to pad
+                                  contents at bottom
+                                • focus_id: (string) if a popup with this id
+                                  is opened, then focus it
+                                • close_events: (table) list of events that
+                                  closes the floating window
+                                • focusable: (boolean, default true) Make
                                   float focusable
 
                 Return: ~

--- a/runtime/doc/pi_msgpack.txt
+++ b/runtime/doc/pi_msgpack.txt
@@ -68,7 +68,7 @@ msgpack#strftime({format}, {msgpack-integer})		*msgpack#strftime()*
 
 							*msgpack#strptime*
 msgpack#strptime({format}, {time})			*msgpack#strptime()*
-	Reverse of |msgpack#strptime()|: for any time and format 
+	Reverse of |msgpack#strftime()|: for any time and format 
 	|msgpack#equal|( |msgpack#strptime|(format, |msgpack#strftime|(format, 
 	time)), time) be true.  Requires |+python| or |+python3|, without it 
 	only supports non-|msgpack-special-dict| nonnegative times and format 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -428,7 +428,7 @@ Working directory (Vim implemented some of these later than Nvim):
 - |DirChanged| can be triggered when switching to another window.
 - |getcwd()| and |haslocaldir()| may throw errors if the tab page or window
   cannot be found.  *E5000* *E5001* *E5002*
-- |haslocaldir()| only checks for tab-local directory when -1 is passed as
+- |haslocaldir()| checks for tab-local directory if and only if -1 is passed as
   window number, and its only possible returns values are 0 and 1.
 - `getcwd(-1)` is equivalent to `getcwd(-1, 0)` instead of returning the global
   working directory. Use `getcwd(-1, -1)` to get the global working directory.

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -807,7 +807,9 @@ end
 ---         - severity: See |diagnostic-severity|.
 ---         - float: (boolean or table, default true) If "true", call |vim.diagnostic.open_float()|
 ---                    after moving. If a table, pass the table as the {opts} parameter to
----                    |vim.diagnostic.open_float()|.
+---                    |vim.diagnostic.open_float()|. Unless overridden, the float will show
+---                    diagnostics at the new cursor position (as if "cursor" were passed to
+---                    the "scope" option).
 ---         - win_id: (number, default 0) Window ID
 function M.goto_next(opts)
   return diagnostic_move_pos(

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -537,26 +537,7 @@ end
 ---                * priority: (number, default 10) Base priority to use for signs. When
 ---                {severity_sort} is used, the priority of a sign is adjusted based on
 ---                its severity. Otherwise, all signs use the same priority.
----       - float: Options for floating windows:
----                  * severity: See |diagnostic-severity|.
----                  * header: (string or table) String to use as the header for the floating
----                            window. If a table, it is interpreted as a [text, hl_group] tuple.
----                            Defaults to "Diagnostics:".
----                  * source: (string) Include the diagnostic source in
----                            the message. One of "always" or "if_many".
----                  * format: (function) A function that takes a diagnostic as input and returns a
----                            string. The return value is the text used to display the diagnostic.
----                  * prefix: (function, string, or table) Prefix each diagnostic in the floating
----                            window. If a function, it must have the signature (diagnostic, i,
----                            total) -> (string, string), where {i} is the index of the diagnostic
----                            being evaluated and {total} is the total number of diagnostics
----                            displayed in the window. The function should return a string which
----                            is prepended to each diagnostic in the window as well as an
----                            (optional) highlight group which will be used to highlight the
----                            prefix. If {prefix} is a table, it is interpreted as a [text,
----                            hl_group] tuple as in |nvim_echo()|; otherwise, if {prefix} is a
----                            string, it is prepended to each diagnostic in the window with no
----                            highlight.
+---       - float: Options for floating windows. See |vim.diagnostic.open_float()|.
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,
 ---                           diagnostics are updated on InsertLeave)
 ---       - severity_sort: (default false) Sort diagnostics by severity. This affects the order in
@@ -564,6 +545,7 @@ end
 ---                         are displayed before lower severities (e.g. ERROR is displayed before WARN).
 ---                         Options:
 ---                         * reverse: (boolean) Reverse sort order
+---
 ---@param namespace number|nil Update the options for the given namespace. When omitted, update the
 ---                            global diagnostic options.
 function M.config(opts, namespace)
@@ -1175,7 +1157,17 @@ end
 ---            - format: (function) A function that takes a diagnostic as input and returns a
 ---                      string. The return value is the text used to display the diagnostic.
 ---                      Overrides the setting from |vim.diagnostic.config()|.
----            - prefix: (function, string, or table) Prefix each diagnostic in the floating window.
+---            - prefix: (function, string, or table) Prefix each diagnostic in the floating
+---                      window. If a function, it must have the signature (diagnostic, i,
+---                      total) -> (string, string), where {i} is the index of the diagnostic
+---                      being evaluated and {total} is the total number of diagnostics
+---                      displayed in the window. The function should return a string which
+---                      is prepended to each diagnostic in the window as well as an
+---                      (optional) highlight group which will be used to highlight the
+---                      prefix. If {prefix} is a table, it is interpreted as a [text,
+---                      hl_group] tuple as in |nvim_echo()|; otherwise, if {prefix} is a
+---                      string, it is prepended to each diagnostic in the window with no
+---                      highlight.
 ---                      Overrides the setting from |vim.diagnostic.config()|.
 ---@return tuple ({float_bufnr}, {win_id})
 function M.open_float(bufnr, opts)

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -230,7 +230,7 @@ function default_dispatchers.on_error(code, err)
 end
 
 --- Starts an LSP server process and create an LSP RPC client object to
---- interact with it. Interactions are currently limited to stdin/stdout.
+--- interact with it. Communication with the server is currently limited to stdio.
 ---
 ---@param cmd (string) Command to start the LSP server.
 ---@param cmd_args (table) List of additional string arguments to pass to {cmd}.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -230,7 +230,7 @@ function default_dispatchers.on_error(code, err)
 end
 
 --- Starts an LSP server process and create an LSP RPC client object to
---- interact with it.
+--- interact with it. Interactions are currently limited to stdin/stdout.
 ---
 ---@param cmd (string) Command to start the LSP server.
 ---@param cmd_args (table) List of additional string arguments to pass to {cmd}.

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1223,18 +1223,18 @@ end
 ---
 ---@param contents table of lines to show in window
 ---@param syntax string of syntax to set for opened buffer
----@param opts dictionary with optional fields
----             - height    of floating window
----             - width     of floating window
----             - wrap boolean enable wrapping of long lines (defaults to true)
----             - wrap_at   character to wrap at for computing height when wrap is enabled
----             - max_width  maximal width of floating window
----             - max_height maximal height of floating window
----             - pad_top    number of lines to pad contents at top
----             - pad_bottom number of lines to pad contents at bottom
----             - focus_id if a popup with this id is opened, then focus it
----             - close_events list of events that closes the floating window
----             - focusable (boolean, default true): Make float focusable
+---@param opts table with optional fields (additional keys are passed on to |vim.api.nvim_open_win()|)
+---             - height: (number) height of floating window
+---             - width: (number) width of floating window
+---             - wrap: (boolean, default true) wrap long lines
+---             - wrap_at: (string) character to wrap at for computing height when wrap is enabled
+---             - max_width: (number) maximal width of floating window
+---             - max_height: (number) maximal height of floating window
+---             - pad_top: (number) number of lines to pad contents at top
+---             - pad_bottom: (number) number of lines to pad contents at bottom
+---             - focus_id: (string) if a popup with this id is opened, then focus it
+---             - close_events: (table) list of events that closes the floating window
+---             - focusable: (boolean, default true) Make float focusable
 ---@returns bufnr,winnr buffer and window number of the newly created floating
 ---preview window
 function M.open_floating_preview(contents, syntax, opts)

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -535,7 +535,7 @@ end:
 /// @param channel_id
 /// @param buffer           Buffer handle, or 0 for current buffer
 /// @param start_row        First line index
-/// @param start_column     Last column
+/// @param start_column     First column
 /// @param end_row          Last line index
 /// @param end_column       Last column
 /// @param replacement      Array of lines to use as replacement

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1246,7 +1246,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
 /// If the current window already shows "buffer", the window is not switched
 /// If a window inside the current tabpage (including a float) already shows the
 /// buffer One of these windows will be set as current window temporarily.
-/// Otherwise a temporary scratch window (calleed the "autocmd window" for
+/// Otherwise a temporary scratch window (called the "autocmd window" for
 /// historical reasons) will be used.
 ///
 /// This is useful e.g. to call vimL functions that only work with the current


### PR DESCRIPTION
- Fixed typo in api.txt
- Fixed type in buffer.c that generates comments in api.txt
- docs: fix two typos in eval.txt
- docs: fix missing "<" in eval.txt
- docs: fix typo in autocmd.txt
- fix(doc): minor typo correction
- fix(doc): correct parameter explanation error
- docs: make a sentence in vim_diff.txt less equivocal
- docs: vim.diagnostic.goto_next defaults to cursor-scoped floats
- Note currently supported JSON-RPC channels in :help.
- Update rpc.lua
- docs(extmarks): fix typo
- chore: fix typo
- docs(diagnostic, lsp): mention passing on of options
