### PR TITLE
Docs/small fixes

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3108,7 +3108,6 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
     Example (Lua): buffer-relative float (travels as buffer is scrolled) >lua
         vim.api.nvim_open_win(0, false,
           {relative='win', width=12, height=3, bufpos={100,10}})
-        })
 <
 
     Attributes: ~

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -179,7 +179,7 @@ if tty then
   --- already set by the user.
   ---
   --- @param option string Option name
-  --- @param value string Option value
+  --- @param value any Option value
   local function setoption(option, value)
     if vim.api.nvim_get_option_info2(option, {}).was_set then
       -- Don't do anything if option is already set

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1491,7 +1491,6 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- ```lua
 ---     vim.api.nvim_open_win(0, false,
 ---       {relative='win', width=12, height=3, bufpos={100,10}})
----     })
 --- ```
 ---
 --- @param buffer integer Buffer to display, or 0 for current buffer

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -68,7 +68,6 @@
 /// ```lua
 /// vim.api.nvim_open_win(0, false,
 ///   {relative='win', width=12, height=3, bufpos={100,10}})
-/// })
 /// ```
 ///
 /// @param buffer Buffer to display, or 0 for current buffer

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -485,7 +485,7 @@ void f_tabpagewinnr(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// Switch to a window for executing user code.
 /// Caller must call win_execute_after() later regardless of return value.
 ///
-/// @return  whether switching the window succeded.
+/// @return  whether switching the window succeeded.
 bool win_execute_before(win_execute_T *args, win_T *wp, tabpage_T *tp)
 {
   args->wp = wp;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -660,7 +660,7 @@ void pum_redraw(void)
   }
 }
 
-/// create a floting preview window for info
+/// create a floating preview window for info
 /// @return  NULL when no enough room to show
 static win_T *pum_create_float_preview(bool enter)
 {
@@ -972,7 +972,7 @@ static bool pum_set_selected(int n, int repeat)
             if (curwin->w_p_wrap) {
               lnum += plines_win(curwin, lnum, true);
             }
-            // adjust floting window by actually height and max info text width
+            // adjust floating window by actually height and max info text width
             pum_adjust_float_position(curwin, lnum, max_info_width);
           }
 


### PR DESCRIPTION
Remove an extra `})` from the docs. Moved over from  https://github.com/neovim/neovim/pull/26753.

Edit: I'm not sure why the earlier commits got lumped in with this PR. Is there something I can do to fix this?